### PR TITLE
initial import from CF 7.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,10 @@ requirements:
   host:
     - python >=3.6
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - future
     - urllib3
     - pytz


### PR DESCRIPTION
The MinIO Python Client SDK provides simple APIs to access any Amazon S3 compatible object storage server.

* [x] upstream repo https://github.com/minio/minio-py
* [x] dev_url, doc_url valid
* [x] check license is accurate
* [x] setuptools/wheel/pip/pip check included
* [x] compare pinned versions from upstream - no pinnings
